### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,10 @@
-#Bob 👷
+# Bob 👷
 
 Bob is an extendable [Slack](https://slack.com/) bot written in Swift used to communicate with [TravisCI](https://travis-ci.com/) and [GitHub](https://github.com/) APIs. It's used to perform tasks of repetitive nature that cannot be fully automatized, such as creating release candidates for the app store.
 
 Simply send a message to Bob on Slack, and it will do the job for you.
 
-##Commands
+## Commands
 Bob operates using commands. It comes with a couple of customizable commands, but new ones can easily be created. See [creating custom commands](#creating-custom-commands) for more information.
 
  All commands are invoked by typing in `{name} parameters`. 
@@ -16,14 +16,14 @@ could trigger a job on Travis that would create a build with `staging` configura
 <br>
 To see how a command should be used, type `{name} usage`
 
-###Hello
+### Hello
 
 A dumy command that can be used to check if Bob is running. Simply say `hello` to Bob, and it will greet you back.
 
-###Version
+### Version
 You can see which version of Bob is currently running by typing `version`
 
-###Travis Script
+### Travis Script
 `TravisScriptCommand` is a configurable command that triggers a job on Travis and executes a script there. The command can have multiple targets that can be specified at runtime.
 <br>The script to run for each target is speficied when the command is instantiated.
 <br>For example:<br>
@@ -37,7 +37,7 @@ try bob.register(buildCommand)
 ```
 would register a command with the name `build`. Typing `build staging` would start the lane `distribute_staging` on Travis.
 
-###Align Version
+### Align Version
 iOS specific command used to change the `CFBundleShortVersionString` and `CFBundleVersion` values in specified `.plist` files.
 <br>For example:<br>
 ```
@@ -51,16 +51,16 @@ try bob.register(alignCommand)
 ```
 would register a command that can be invoked by typing `align 3.0 4`. Bob would than create a commit on GitHub by changing the 3 specified files.
 
-##Getting started
+## Getting started
 
-###Creating a bot on Slack
+### Creating a bot on Slack
 Bob requires a slack token in order to work. You can obtain one by creating a slack bot:<br>
 1. Open the custom integration page <br>
 2. Select `Bots` <br>
 3. Type in a username for your bot. `bobthebuilder` works out nicely <br>
 4. Copy the `API Token` field. Bob will use this to connect to slack<br>
 
-###Starting it up
+### Starting it up
 Bob can be set up just as any other Swift Package, but since it relies on [Vapor💧](https://vapor.codes/) we recommend setting it up with the Vapor toolbox. To install vapor toolbox you can follow [the manual](https://github.com/vapor/toolbox)<br>
 
 Once you have the toolbox setup, you can start by creating a new project:<br>
@@ -101,18 +101,18 @@ try bob.start()
 ```
 and you're good to go. Select the `App` scheme and run it. You can now send messages to `Bob` via Slack, and it will respond.
 
-###Using the TravisCI API
+### Using the TravisCI API
 In order to use commands that communicate with the TravisCI API, you will need to provide a configuration. The configuration consists of
 * Url of the repo on Travis. Along the lines of `https://api.travis-ci.com/repo/{owner%2Frepo}`
 * Access token. You can obtain one by running `gem install travis && travis login && travis token`
 
-###Using the GitHub API
+### Using the GitHub API
 In order to use commands that communicate with the GitHub API, you will need to provide a configuration. The configuration consists of
 * Your GitHub username
 * A personal access token with read/write permissions. See [this link](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) on instructions how to generate one
 * Url of the repo on GitHub. Alogn the lines of `https://api.github.com/repos/{owner}/{repo}`
 
-##Command chaining
+## Command chaining
 Bob supports sending multiple commands using 1 slack message. Just separate commands using `|` .
 <br> For example:<br>
 ```
@@ -120,7 +120,7 @@ sync strings | align 3.0 5 | build staging | build testflight
 ```
 could be used when creating a release candidate for the app store. It would update the strings on the repository, set the version and build the app for 2 environments 
 
-##Creating custom commands
+## Creating custom commands
 Custom commands can be created an provdided to Bob. To create a command implement the `Command` protocol.
 ```
 public protocol Command {
@@ -149,9 +149,9 @@ The actual work happens in the `execute` method. All of the parameters the user 
 
 Bob comes with a subset of TravisCI and GitHub APIs written in swift.
 
-####TravisCI
+#### TravisCI
 Only contains a method to execute a script exposed via the `TravisScriptCommand`
-####GitHub
+#### GitHub
 Contains low level methods for manipulating files and trees on GitHub. For the complete set of methods, check [GitHub.swift](Sources/Bob/APIs/GitHub/GitHub.swift)
 <br>
 * For utility methods to create a commit by updating a set of files, check [GitHub+FileUpdating.swift](Sources/Bob/APIs/GitHub/GitHub%2BFileUpdating.swift)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it. The space between the last # and the first letter is not accepted anymore.