### PR TITLE
[Vapor 3] Added parsing tests

### DIFF
--- a/Sources/Bob/APIs/GitHub/GitHub.swift
+++ b/Sources/Bob/APIs/GitHub/GitHub.swift
@@ -67,7 +67,7 @@ public class GitHub {
     private let repoUrl: String
     private let app: Application
 
-    var worker: Worker {
+    public var worker: Worker {
         return app
     }
 

--- a/Sources/Bob/APIs/GitHub/GitHubTypes.swift
+++ b/Sources/Bob/APIs/GitHub/GitHubTypes.swift
@@ -21,6 +21,8 @@ import Vapor
 public typealias TreeItem = GitHub.Git.TreeItem
 public typealias Tree = GitHub.Git.Tree
 public typealias GitCommit = GitHub.Git.Commit
+public typealias GitContent = GitHub.Repos.GitContent
+public typealias RepoCommit = GitHub.Repos.Commit
 public typealias Branch = GitHub.Repos.Branch
 public typealias BranchName = GitHub.Repos.Branch.BranchName
 public typealias Author = GitHub.Author
@@ -92,6 +94,7 @@ extension GitHub {
             public let author: Author
             public let committer: Author
             public let tree: Tree
+            public let url: URL
         }
 
         public struct Tree: Content {
@@ -170,11 +173,26 @@ extension GitHub {
             let commit: Commit
         }
 
+        /// https://developer.github.com/v3/repos/commits/#get-a-single-commit
         public struct Commit: Content {
             public typealias SHA = String
 
+            public struct Details: Content {
+                public let message: String
+                public let author: Author
+                public let committer: Author
+            }
+
             public let sha: SHA
-            public let url: URL
+            public let htmlUrl: URL
+            public let details: Details
+
+            enum CodingKeys: String, CodingKey {
+                case sha
+                case htmlUrl
+                case details = "commit"
+            }
+
         }
 
         public enum GitContent: Content {

--- a/Tests/BobTests/API/GitHub/GitHubTypesDecodingTests.swift
+++ b/Tests/BobTests/API/GitHub/GitHubTypesDecodingTests.swift
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 N26 GmbH.
+ *
+ * This file is part of Bob.
+ *
+ * Bob is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bob is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Bob.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import XCTest
+@testable import Bob
+
+
+let decoder = GitHub.decoder
+
+func AssertDecodes<T: Response>(model: T.Type, file: StaticString = #file, line: UInt = #line) {
+    do {
+        let model = try decoder.decode(T.self, from: model.response)
+        print(model)
+    } catch {
+        XCTFail("Decoding failed: \(error)", file: file, line: line)
+    }
+}
+
+class GitHubTypesDecodingTests: XCTestCase {
+
+    func test_gitCommit_decodes() throws {
+        AssertDecodes(model: GitHub.Git.Commit.self)
+    }
+
+    func test_gitTree_decodes() throws {
+        AssertDecodes(model: GitHub.Git.Tree.self)
+    }
+
+    func test_repoCommit_decodes() throws {
+        AssertDecodes(model: GitHub.Repos.Commit.self)
+    }
+}

--- a/Tests/BobTests/API/GitHub/Resources/GitHubTypesResources.swift
+++ b/Tests/BobTests/API/GitHub/Resources/GitHubTypesResources.swift
@@ -1,0 +1,188 @@
+//
+//  GitHubTypesResources.swift
+//  BobTests
+//
+//  Created by Jan Chaloupecky on 20.08.19.
+//
+
+import Foundation
+import Bob
+
+
+protocol Response: Decodable {
+    static var response: Data { get }
+}
+
+extension GitHub.Git.Commit: Response {
+
+    static var response: Data {
+        return """
+        {
+          "sha": "7638417db6d59f3c431d3e1f261cc637155684cd",
+          "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd",
+          "author": {
+            "date": "2014-11-07T22:01:45Z",
+            "name": "Monalisa Octocat",
+            "email": "octocat@github.com"
+          },
+          "committer": {
+            "date": "2014-11-07T22:01:45Z",
+            "name": "Monalisa Octocat",
+            "email": "octocat@github.com"
+          },
+          "message": "added readme, because im a good github citizen",
+          "tree": {
+            "url": "https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb",
+            "sha": "691272480426f78a0138979dd3ce63b77f706feb"
+          },
+          "parents": [
+            {
+              "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5",
+              "sha": "1acc419d4d6a9ce985db7be48c6349a0475975b5"
+            }
+          ],
+          "verification": {
+            "verified": false,
+            "reason": "unsigned",
+            "signature": null,
+            "payload": null
+          }
+        }
+        """.data(using: .utf8)!
+    }
+}
+
+extension GitHub.Git.Tree: Response {
+    static var response: Data = """
+    {
+      "sha": "9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+      "url": "https://api.github.com/repos/octocat/Hello-World/trees/9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+      "tree": [
+        {
+          "path": "file.rb",
+          "mode": "100644",
+          "type": "blob",
+          "size": 30,
+          "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+          "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132"
+        },
+        {
+          "path": "subdir",
+          "mode": "040000",
+          "type": "tree",
+          "sha": "f484d249c660418515fb01c2b9662073663c242e",
+          "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/f484d249c660418515fb01c2b9662073663c242e"
+        },
+        {
+          "path": "exec_file",
+          "mode": "100755",
+          "type": "blob",
+          "size": 75,
+          "sha": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
+          "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
+        }
+      ],
+      "truncated": false
+    }
+    """.data(using: .utf8)!
+}
+
+extension GitHub.Repos.Commit: Response {
+    static var response: Data = """
+    {
+      "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "node_id": "MDY6Q29tbWl0NmRjYjA5YjViNTc4NzVmMzM0ZjYxYWViZWQ2OTVlMmU0MTkzZGI1ZQ==",
+      "html_url": "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "comments_url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e/comments",
+      "commit": {
+        "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+        "author": {
+          "name": "Monalisa Octocat",
+          "email": "support@github.com",
+          "date": "2011-04-14T16:00:49Z"
+        },
+        "committer": {
+          "name": "Monalisa Octocat",
+          "email": "support@github.com",
+          "date": "2011-04-14T16:00:49Z"
+        },
+        "message": "Fix all the bugs",
+        "tree": {
+          "url": "https://api.github.com/repos/octocat/Hello-World/tree/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+          "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+        },
+        "comment_count": 0,
+        "verification": {
+          "verified": false,
+          "reason": "unsigned",
+          "signature": null,
+          "payload": null
+        }
+      },
+      "author": {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "committer": {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "parents": [
+        {
+          "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+          "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+        }
+      ],
+      "stats": {
+        "additions": 104,
+        "deletions": 4,
+        "total": 108
+      },
+      "files": [
+        {
+          "filename": "file1.txt",
+          "additions": 10,
+          "deletions": 2,
+          "changes": 12,
+          "status": "modified",
+          "raw_url": "https://github.com/octocat/Hello-World/raw/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt",
+          "blob_url": "https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt",
+          "patch": ""
+        }
+      ]
+    }
+    """.data(using: .utf8)!
+}


### PR DESCRIPTION
Migrating 👷‍♂️to Vapor 3

- Added GitHub parsing tests
- Added a `GitHub.Repos.Commit` struct
- Exposed the `worker` to facilitate creating `Futures` when using the API. E.g. `return github.worker.future("foo"`)