### PR TITLE
[Vapor 3] Use Containers instead of Application

### DIFF
--- a/Sources/Bob/APIs/GitHub/GitHub.swift
+++ b/Sources/Bob/APIs/GitHub/GitHub.swift
@@ -65,16 +65,16 @@ public class GitHub {
     
     private let authorization: BasicAuthorization
     private let repoUrl: String
-    private let app: Application
+    private let container: Container
 
     public var worker: Worker {
-        return app
+        return container
     }
 
-    public init(config: Configuration, app: Application) {
+    public init(config: Configuration, container: Container) {
         self.authorization = BasicAuthorization(username: config.username, password: config.personalAccessToken)
         self.repoUrl = config.repoUrl
-        self.app = app
+        self.container = container
     }
     
     private func uri(at path: String) -> String {
@@ -175,10 +175,10 @@ public class GitHub {
     // MARK: - Private
 
     private func get<T: Content>(_ uri: String) throws -> Future<T> {
-        return try app.client().get(uri, using: GitHub.decoder, authorization: authorization)
+        return try container.client().get(uri, using: GitHub.decoder, authorization: authorization)
     }
 
     private func post<Body: Content, T: Content>(body: Body, to uri: String, patch: Bool = false ) throws -> Future<T> {
-        return try app.client().post(body: body, to: uri, encoder: GitHub.encoder, using: GitHub.decoder, method: patch ? .PATCH : .POST, authorization: authorization)
+        return try container.client().post(body: body, to: uri, encoder: GitHub.encoder, using: GitHub.decoder, method: patch ? .PATCH : .POST, authorization: authorization)
     }
 }

--- a/Sources/Bob/APIs/TravisCI/TravisCI.swift
+++ b/Sources/Bob/APIs/TravisCI/TravisCI.swift
@@ -54,10 +54,10 @@ public class TravisCI {
     }
     
     private let config: Configuration
-    private let app: Application
+    private let container: Container
 
     public var worker: Worker {
-        return app
+        return container
     }
 
     private lazy var headers: HTTPHeaders = {
@@ -72,9 +72,9 @@ public class TravisCI {
     /// Initializes the object with provided configuration
     ///
     /// - Parameter config: Configuration to use
-    public init(config: Configuration, app: Application) {
+    public init(config: Configuration, container: Container) {
         self.config = config
-        self.app = app
+        self.container = container
     }
     
     /// Triggers a TravisCI job executing a script named `script`
@@ -94,7 +94,7 @@ public class TravisCI {
             ]
         ]
 
-        let futureResponse = try app.client().post(uri, headers: headers) { request in
+        let futureResponse = try container.client().post(uri, headers: headers) { request in
             request.http.body = HTTPBody(data: try body.makeJSON())
         }
 


### PR DESCRIPTION
The services can use directly a service `Container` instead of `Application` for getting the `client` service.

