### PR TITLE
[Vapor 3] Better exception message when Slack token is invalid

### DIFF
--- a/Sources/Bob/Core/Slack/SlackTypes.swift
+++ b/Sources/Bob/Core/Slack/SlackTypes.swift
@@ -21,7 +21,7 @@ import Foundation
 
 // https://api.slack.com/methods/rtm.start
 struct SlackStartResponse: Decodable {
-    let url: URL
+    let url: URL?
 }
 
 enum SlackMessageType: String, Encodable {


### PR DESCRIPTION
When the slack token is invalid, the exception message was the one from a Decoding which was not clear enough.

This PR adds a more explicit failure