### PR TITLE
Ignore slack message originating from another Bob

### DIFF
--- a/Sources/Bob/Core/Slack/SlackTypes.swift
+++ b/Sources/Bob/Core/Slack/SlackTypes.swift
@@ -21,7 +21,25 @@ import Foundation
 
 // https://api.slack.com/methods/rtm.start
 struct SlackStartResponse: Decodable {
-    let url: URL?
+    let ok: Bool
+
+    struct Success: Decodable {
+        let url: URL
+        let me: User
+
+        enum CodingKeys: String, CodingKey {
+            case url = "url"
+            case me = "self"
+        }
+
+        struct User: Decodable {
+            let id: String
+        }
+    }
+
+    struct Error: Decodable {
+        let error: String
+    }
 }
 
 enum SlackMessageType: String, Encodable {


### PR DESCRIPTION
In case there are several instance of Bob running, each Slack message response from one Bob would be considered as a command to another Bob creating a Slack ~Bob to Bob conversation~ infinite loop.

To prevent this, we can compare the slack user ids of the message sender and Bob and ignore the message if they are the same. The `id` of Bob is returned in the initial rtm.start response:

```json
{
  "ok": true,
  "url": "wss://...",
  "self": {
    "id": "xxxxx",
    "name": "Bob"
  }
}
```

- Check for the `ok: true` if the [rtm.start](https://api.slack.com/methods/rtm.start) before parsing it
- Parse our slack id in the rtm.start response
- Compare command sender's uid with ours