### PR TITLE
[Bob] Do not reconnect on error

### DIFF
--- a/Sources/Bob/Core/Bob.swift
+++ b/Sources/Bob/Core/Bob.swift
@@ -21,7 +21,7 @@ import Foundation
 import Vapor
 
 public class Bob {
-    static let version: String = "2.1.2"
+    static let version: String = "2.1.3"
     
     /// Struct containing all properties needed for Bob to function
     public struct Configuration {

--- a/Sources/Bob/Core/Slack/SlackClient.swift
+++ b/Sources/Bob/Core/Slack/SlackClient.swift
@@ -111,8 +111,10 @@ class SlackClient {
 
                 ws.onError { ws, error in
                     logger.error("ws onError: \(error)")
-                    self.reconnectWithTimeout()
+                    ws.close()
                 }
+
+                logger.info("Connected to Slack")
                 return ws.onClose
             }.map {
                 logger.info("ws close")
@@ -125,7 +127,6 @@ class SlackClient {
         }.catch { error in
             logger.error("Failed to request RTM url: \(error)")
         }
-        logger.info("Connected to Slack")
     }
 
     private func reconnectWithTimeout() {


### PR DESCRIPTION
Reconnecting in the `onError` callback was causing multiple connections to the WS server as `onError` does not necessarily mean the connection was lost. 

Instead, we now close the ws connection in the `onError` which will trigger the `onClose` followed by the call to `reconnectWithTimeout`