### PR TITLE
[Bob] Lowered log verbosity

### DIFF
--- a/Sources/Bob/Core/Bob.swift
+++ b/Sources/Bob/Core/Bob.swift
@@ -21,7 +21,7 @@ import Foundation
 import Vapor
 
 public class Bob {
-    static let version: String = "2.1.3"
+    static let version: String = "2.1.4"
     
     /// Struct containing all properties needed for Bob to function
     public struct Configuration {

--- a/Sources/Bob/Core/Slack/SlackClient.swift
+++ b/Sources/Bob/Core/Slack/SlackClient.swift
@@ -138,17 +138,15 @@ class SlackClient {
 
     // MARK: - Event handling
     private  func onText(ws: WebSocket, text: String, me: SlackStartResponse.Success.User, logger: Logger) {
-        logger.debug("[event] - \(text)")
-
         do {
             guard let event = try self.event(fromText: text) else { return }
-
             switch event {
             case .message(let message):
                 guard message.user != me.id else {
                     logger.warning("Ignoring message from another instance of myself: '\(message.text)'")
                     return
                 }
+                logger.debug("Received message: '\(message.text)'")
                 let sender = SlackMessageSender(socket: ws, channel: message.channel)
                 onMessage?(message.text, sender)
             case .goodbye:


### PR DESCRIPTION
Logging all received Slack events from the organisation could cause a lot of logs. This is not appropriate especially when publishing the logs to Logstash or other.

We now log only the events that we can handle.