### PR TITLE
[Bob] Added info command

### DIFF
--- a/Sources/Bob/Commands/Info/Info Providers/EnvironmentInfoProvider.swift
+++ b/Sources/Bob/Commands/Info/Info Providers/EnvironmentInfoProvider.swift
@@ -1,0 +1,24 @@
+//
+//  EnvironmentInfoProvider.swift
+//  Bob
+//
+//  Created by Jan Chaloupecky on 02.12.19.
+//
+
+import Foundation
+import Service
+
+public struct EnvironmentInfoProvider: InfoProvider {
+    private let key: String
+
+    public init(key: String) {
+        self.key = key
+    }
+    public var name: String {
+        return "env \(key)"
+    }
+
+    public var value: String {
+        return Environment.get(key) ?? ""
+    }
+}

--- a/Sources/Bob/Commands/Info/Info Providers/InfoProvider.swift
+++ b/Sources/Bob/Commands/Info/Info Providers/InfoProvider.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Used by the `InfoCommand` to provide a name and value to the list
-/// Use you can register a provider infoCommand.register(MyInfoProvider())
+/// Use you can register a provider using `infoCommand.register(MyInfoProvider())`
 public protocol InfoProvider {
     /// The name of the provided information printed to Slack
     var name: String { get }

--- a/Sources/Bob/Commands/Info/Info Providers/InfoProvider.swift
+++ b/Sources/Bob/Commands/Info/Info Providers/InfoProvider.swift
@@ -1,0 +1,18 @@
+//
+//  InfoProvider.swift
+//  Bob
+//
+//  Created by Jan Chaloupecky on 02.12.19.
+//
+
+import Foundation
+
+/// Used by the `InfoCommand` to provide a name and value to the list
+/// Use you can register a provider infoCommand.register(MyInfoProvider())
+public protocol InfoProvider {
+    /// The name of the provided information printed to Slack
+    var name: String { get }
+
+    /// The value of the provided information printed to Slack
+    var value: String { get }
+}

--- a/Sources/Bob/Commands/Info/Info Providers/InstanceIdInfoProvider.swift
+++ b/Sources/Bob/Commands/Info/Info Providers/InstanceIdInfoProvider.swift
@@ -1,0 +1,13 @@
+//
+//  InstanceIdInfoProvider.swift
+//  Bob
+//
+//  Created by Jan Chaloupecky on 02.12.19.
+//
+
+import Foundation
+
+public struct InstanceIdInfoProvider: InfoProvider {
+    public let name = "Instance Id"
+    public let value = UUID().uuidString
+}

--- a/Sources/Bob/Commands/Info/Info Providers/UptimeInfoProvider.swift
+++ b/Sources/Bob/Commands/Info/Info Providers/UptimeInfoProvider.swift
@@ -1,0 +1,22 @@
+//
+//  UptimeInfoProvider.swift
+//  Bob
+//
+//  Created by Jan Chaloupecky on 02.12.19.
+//
+
+import Foundation
+
+struct UptimeInfoProvider: InfoProvider {
+    private let date = Date()
+    private let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, yyyy HH:mm"
+        return formatter
+    }()
+
+    var name = "Uptime since"
+    var value: String {
+        return "\(formatter.string(from: date))"
+    }
+}

--- a/Sources/Bob/Commands/Info/InfoCommand.swift
+++ b/Sources/Bob/Commands/Info/InfoCommand.swift
@@ -1,0 +1,45 @@
+//
+//  InfoCommand.swift
+//  Bob
+//
+//  Created by Jan Chaloupecky on 02.12.19.
+//
+
+import Foundation
+
+
+/// The `InfoCommand` prints a list of key/values provided by `InfoProvider`
+/// It's meant to provide info about a running instance of Bob
+public class InfoCommand: Command {
+    private var providers: [InfoProvider] = [
+        InstanceIdInfoProvider(),
+        UptimeInfoProvider()
+    ]
+    public let name = "info"
+
+    public init() {
+
+    }
+    public var usage: String {
+        return "`info` prints information about the Bob instance"
+    }
+
+    public func execute(with parameters: [String], replyingTo sender: MessageSender) throws {
+
+        let result = providers
+            .map { "\($0.name): \($0.value)" }
+            .reduce("") { $0 + $1 + "\n" }
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let response = """
+        ```
+        \(result)
+        ```
+        """
+        sender.send(response)
+    }
+
+    public func register(_ provider: InfoProvider) {
+        providers.append(provider)
+    }
+}

--- a/Sources/Bob/Core/Bob.swift
+++ b/Sources/Bob/Core/Bob.swift
@@ -21,7 +21,7 @@ import Foundation
 import Vapor
 
 public class Bob {
-    static let version: String = "2.1.4"
+    static let version: String = "2.1.5"
     
     /// Struct containing all properties needed for Bob to function
     public struct Configuration {


### PR DESCRIPTION
This adds a `info` command that allows to print some runtime infos about a running Bob instance

```swift
try bob.register(InfoCommand())
```



> Jan:
> info
> bob:
> ```
> Instance Id: DCF58B77-AF92-454F-9BC0-61CA8BA17113
> Uptime since: Dec 2, 2019 14:23
> ```
