### PR TITLE
Output Travis build URL after executing a travis build command

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,7 @@ disabled_rules:
  - force_cast 
  - force_try 
  - trailing_whitespace
+ - nesting
 
 analyzer_rules:
  - explicit_self
@@ -31,7 +32,7 @@ opt_in_rules:
 included:
  - Sources
 large_tuple: 5 
-line_length: 150
+line_length: 250
 type_body_length:
   warning: 300
   error: 400
@@ -39,10 +40,12 @@ file_length:
   warning: 500
   error: 1200
 type_name:
-  min_length: 4
+  min_length: 3
   max_length:
     warning: 40
     error: 50
+  excluded:
+    - ID
 identifier_name:
   min_length:
     error: 3
@@ -50,5 +53,11 @@ identifier_name:
     - id
     - up
     - i
+    - j
+    - m
+    - n
     - to
+    - ws
+    - me
+    - ok
 reporter: "xcode"

--- a/Sources/Bob/APIs/GitHub/GitHub+FileUpdating.swift
+++ b/Sources/Bob/APIs/GitHub/GitHub+FileUpdating.swift
@@ -121,7 +121,6 @@ public extension GitHub {
 
         // wait for both repo state and updated items to create a new tree
         let newTree = flatMap(to: Tree.self, respositoryState, updatedItems) { respositoryState, updatedItems in
-
             if updatedItems.isEmpty {
                 throw "The updater \(updater) did not match any items to update"
             }

--- a/Sources/Bob/APIs/GitHub/GitHubTypes.swift
+++ b/Sources/Bob/APIs/GitHub/GitHubTypes.swift
@@ -71,7 +71,7 @@ extension GitHub {
     }
 
     /// https://developer.github.com/v3/git/
-    public struct Git {
+    public enum Git {
         public struct Commit: Content {
             public typealias SHA = String
 
@@ -155,7 +155,7 @@ extension GitHub {
     }
 
     /// https://developer.github.com/v3/repos/
-    public struct Repos {
+    public enum Repos {
         /// Struct representing a Branch.
         /// Only contains name since it is the only
         /// property used by current functionality

--- a/Sources/Bob/APIs/TravisCI/JSONDecoder+Travis.swift
+++ b/Sources/Bob/APIs/TravisCI/JSONDecoder+Travis.swift
@@ -1,0 +1,16 @@
+//
+//  JSONDecoder+Travis.swift
+//  Bob
+//
+//  Created by Jan Chaloupecky on 05.12.19.
+//
+
+import Foundation
+
+extension JSONDecoder {
+    static let travis: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+}

--- a/Sources/Bob/APIs/TravisCI/TravisCI.swift
+++ b/Sources/Bob/APIs/TravisCI/TravisCI.swift
@@ -76,7 +76,6 @@ public class TravisCI {
             return (repoUrl.removingPercentEncoding ?? repoUrl)
                 .replacingOccurrences(of: "api.", with: "")
                 .replacingOccurrences(of: "/repo", with: "")
-
         }
         /// Access token
         public let token: String
@@ -163,10 +162,8 @@ public class TravisCI {
 
     /// GET /request/{requestId}
     public func request(id: Request.ID) throws -> Future<TravisCI.Request> {
-
         return try get(uri(at: "/request/\(id)"))
     }
-
 
     public enum Poll<PollResult> {
         case `continue`

--- a/Sources/Bob/APIs/TravisCI/TravisCI.swift
+++ b/Sources/Bob/APIs/TravisCI/TravisCI.swift
@@ -71,6 +71,13 @@ public class TravisCI {
     public struct Configuration {
         /// Url of the repo. Along the lines of https://api.travis-ci.com/repo/{owner%2Frepo}
         public let repoUrl: String
+
+        public var dashboardUrl: String {
+            return (repoUrl.removingPercentEncoding ?? repoUrl)
+                .replacingOccurrences(of: "api.", with: "")
+                .replacingOccurrences(of: "/repo", with: "")
+
+        }
         /// Access token
         public let token: String
         public init(repoUrl: String, token: String) {
@@ -108,7 +115,7 @@ public class TravisCI {
     /// - Parameters:
     ///   - script: Script to execute. The script should be in the repo
     ///   - branch: Branch to use when executing the script
-    public func execute(_ script: Script, on branch: String) throws -> Future<Bool> {
+    public func execute(_ script: Script, on branch: String) throws -> Future<TravisCI.Requests.Response> {
         let uri = self.config.repoUrl + "/requests"
         var config = script.config
         config["script"] = script.content
@@ -124,12 +131,12 @@ public class TravisCI {
             request.http.body = HTTPBody(data: try body.makeJSON())
         }
 
-        return futureResponse.map { response in
-            return response.http.status.isSuccessfulRequest
+        return futureResponse.flatMap { response in
+            return try self.container.client().decode(response: response, using: .travis)
         }
     }
 
-    public func execute(title: String, buildParameters: BuildParams) throws -> Future<Bool> {
+    public func execute(title: String, buildParameters: BuildParams) throws -> Future<TravisCI.Requests.Response> {
         let uri = self.config.repoUrl + "/requests"
 
         let body = [
@@ -144,8 +151,79 @@ public class TravisCI {
             request.http.body = HTTPBody(data: try body.makeJSON())
         }
 
-        return futureResponse.map { response in
-            return response.http.status.isSuccessfulRequest
+        return futureResponse.flatMap { response in
+            return try self.container.client().decode(response: response, using: .travis)
         }
+    }
+
+    /// GET /requests
+    public func requests() throws -> Future<TravisCI.Requests> {
+        return try get(uri(at: "/requests"))
+    }
+
+    /// GET /request/{requestId}
+    public func request(id: Request.ID) throws -> Future<TravisCI.Request> {
+
+        return try get(uri(at: "/request/\(id)"))
+    }
+
+
+    public enum Poll<PollResult> {
+        case `continue`
+        case stop(PollResult)
+    }
+
+    /// Polls the /request/{requestId} endpoint until the the `until` returns `.stop`
+    ///
+    /// ```
+    ///     try self.travis.poll(requestId: 123) { request -> TravisCI.Poll<String> in
+    ///         switch request.state {
+    ///         case .pending:
+    ///            return .continue
+    ///         case .complete(let completedRequest):
+    ///             return .stop(completedRequest.commit.message)
+    ///         }
+    ///     }.map { result in
+    ///         print("Travis request commit is \(result)")
+    ///     }
+    /// ```
+    ///
+    /// - Parameter id: The id of the Travis request
+    /// - Parameter until: Closure called on each poll call. Return `.continue` if a next poll should be set or `.stop` with an associated generic value of the polling should stop
+
+    public func poll<PollResult>(requestId: Request.ID, until: @escaping (TravisCI.Request) -> Poll<PollResult>) throws -> Future<PollResult> {
+        let promise = container.eventLoop.newPromise(PollResult.self)
+        try doPoll(requestId: requestId, until: until, promise: promise)
+        return promise.futureResult
+    }
+
+    private func doPoll<PollResult>(requestId id: Request.ID, until: @escaping (TravisCI.Request) -> Poll<PollResult>, promise: Promise<PollResult>) throws {
+        _ = try request(id: id).map { request in
+            let poll = until(request)
+            switch poll {
+            case .continue:
+                self.container.eventLoop.scheduleTask(in: TimeAmount.seconds(TimeAmount.Value(1))) {
+                    try self.doPoll(requestId: id, until: until, promise: promise)
+                }
+            case .stop(let result):
+                promise.succeed(result: result)
+            }
+        }.catch { error in
+            promise.fail(error: error)
+        }
+    }
+
+    public func buildURL(from build: TravisCI.Build) -> URL {
+        let url = URL(string: config.dashboardUrl + "/builds/\(build.id)")!
+        return url
+    }
+    // MARK: - Private
+
+    private func uri(at path: String) -> String {
+        return self.config.repoUrl + path
+    }
+
+    private func get<T: Decodable>(_ uri: String) throws -> Future<T> {
+        return try container.client().get(uri, using: .travis, headers: headers)
     }
 }

--- a/Sources/Bob/APIs/TravisCI/TravisTypes.swift
+++ b/Sources/Bob/APIs/TravisCI/TravisTypes.swift
@@ -11,10 +11,8 @@ import Vapor
 public extension TravisCI {
     /// https://developer.travis-ci.com/resource/requests#Requests
     struct Requests: Codable {
-
         /// POST /requests
         public struct Response: Content {
-
             /// The travis POSTed Travis Request
             public struct Request: Content {
                 public typealias ID = Int
@@ -35,7 +33,6 @@ public extension TravisCI {
         We use the `State` enum here to have a type safe object
     */
     struct Request: Codable {
-
         public enum State {
             case pending
             case complete(Complete)
@@ -64,9 +61,8 @@ public extension TravisCI {
         public let stateRaw: String
         public let state: State
 
-        // MARK:-  Decodable
+        // MARK: - Decodable
         public init(from decoder: Decoder) throws {
-
             let container = try decoder.container(keyedBy: CodingKeys.self)
             id = try container.decode(ID.self, forKey: .id)
             stateRaw = try container.decode(String.self, forKey: .state)
@@ -79,7 +75,7 @@ public extension TravisCI {
             }
         }
 
-        // MARK:- Encodable
+        // MARK: - Encodable
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
@@ -94,7 +90,6 @@ public extension TravisCI {
             }
         }
     }
-
 
     /// https://developer.travis-ci.com/resource/build#Build
     struct Build: Content {

--- a/Sources/Bob/APIs/TravisCI/TravisTypes.swift
+++ b/Sources/Bob/APIs/TravisCI/TravisTypes.swift
@@ -1,0 +1,114 @@
+//
+//  TravisTypes.swift
+//  Bob
+//
+//  Created by Jan Chaloupecky on 03.12.19.
+//
+
+import Foundation
+import Vapor
+
+public extension TravisCI {
+    /// https://developer.travis-ci.com/resource/requests#Requests
+    struct Requests: Codable {
+
+        /// POST /requests
+        public struct Response: Content {
+
+            /// The travis POSTed Travis Request
+            public struct Request: Content {
+                public typealias ID = Int
+                public let id: ID
+                public let branch: String
+            }
+            public let request: Request
+        }
+
+        let requests: [Request]
+    }
+
+    /**
+        https://developer.travis-ci.com/resource/request
+
+        When the Travis Request is "loading", t does not contain the "branch_name", "commit" and "builds".
+        The same response does contain those properties when it's not "loading".
+        We use the `State` enum here to have a type safe object
+    */
+    struct Request: Codable {
+
+        public enum State {
+            case pending
+            case complete(Complete)
+        }
+
+        /**
+         The Resquest object when it's in a non "loading" state
+         */
+        public struct Complete: Decodable {
+            public let id: ID
+            public let branchName: String
+            public let commit: Commit
+            public let builds: [Build]
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case state
+            case id
+            case branchName
+            case builds
+            case commit
+        }
+
+        public typealias ID = Int
+        public let id: ID
+        public let stateRaw: String
+        public let state: State
+
+        // MARK:-  Decodable
+        public init(from decoder: Decoder) throws {
+
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(ID.self, forKey: .id)
+            stateRaw = try container.decode(String.self, forKey: .state)
+            switch stateRaw {
+            case "pending":
+                state = .pending
+            default:
+                let singleContainer = try decoder.singleValueContainer()
+                state = .complete(try singleContainer.decode(Complete.self))
+            }
+        }
+
+        // MARK:- Encodable
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(stateRaw, forKey: .state)
+            switch state {
+            case .pending:
+                break
+            case .complete(let complete):
+                try container.encode(complete.branchName, forKey: .branchName)
+                try container.encode(complete.builds, forKey: .builds)
+                try container.encode(complete.commit, forKey: .commit)
+            }
+        }
+    }
+
+
+    /// https://developer.travis-ci.com/resource/build#Build
+    struct Build: Content {
+        public typealias ID = Int
+        public let href: String
+        public let id: ID
+
+        enum CodingKeys: String, CodingKey {
+            case href = "@href"
+            case id
+        }
+    }
+
+    struct Commit: Content {
+        public let message: String
+    }
+}

--- a/Sources/Bob/Commands/Align Version/AlignVersionCommand.swift
+++ b/Sources/Bob/Commands/Align Version/AlignVersionCommand.swift
@@ -22,7 +22,7 @@ import Vapor
 
 /// Command used to change the version and build numbers directly on GitHub
 public class AlignVersionCommand {
-    struct Constants {
+    enum Constants {
         static let defaultBuildNumber: String = "1"
         static let branchSpecifier: String = "-b"
     }

--- a/Sources/Bob/Commands/Bump/BumpCommand.swift
+++ b/Sources/Bob/Commands/Bump/BumpCommand.swift
@@ -22,7 +22,7 @@ import Vapor
 
 // Command used to bump up build numbers directly on GitHub
 public class BumpCommand {
-    struct Constants {
+    enum Constants {
         static let branchSpecifier: String = "-b"
     }
     

--- a/Sources/Bob/Commands/Info/InfoCommand.swift
+++ b/Sources/Bob/Commands/Info/InfoCommand.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 /// The `InfoCommand` prints a list of key/values provided by `InfoProvider`
 /// It's meant to provide info about a running instance of Bob
 public class InfoCommand: Command {
@@ -18,14 +17,12 @@ public class InfoCommand: Command {
     public let name = "info"
 
     public init() {
-
     }
     public var usage: String {
         return "`info` prints information about the Bob instance"
     }
 
     public func execute(with parameters: [String], replyingTo sender: MessageSender) throws {
-
         let result = providers
             .map { "\($0.name): \($0.value)" }
             .reduce("") { $0 + $1 + "\n" }

--- a/Sources/Bob/Commands/Travis Script/TravisScriptCommand.swift
+++ b/Sources/Bob/Commands/Travis Script/TravisScriptCommand.swift
@@ -60,7 +60,7 @@ public class TravisScriptCommand {
 }
 
 extension TravisScriptCommand: Command {
-    struct Constants {
+    enum Constants {
         static let branchSpecifier: String = "-b"
     }
 

--- a/Sources/Bob/Core/Bob.swift
+++ b/Sources/Bob/Core/Bob.swift
@@ -21,7 +21,7 @@ import Foundation
 import Vapor
 
 public class Bob {
-    static let version: String = "2.1.5"
+    static let version: String = "2.2.0"
     
     /// Struct containing all properties needed for Bob to function
     public struct Configuration {

--- a/Sources/Bob/Core/Extensions/Client+Extensions.swift
+++ b/Sources/Bob/Core/Extensions/Client+Extensions.swift
@@ -26,12 +26,15 @@ extension Response {
 
 public extension Client {
 
-    func get<T: Content>(_ uri: String, using decoder: JSONDecoder = JSONDecoder(), authorization: BasicAuthorization? = nil) throws -> Future<T> {
-        let request = HTTPRequest(method: .GET, url: uri)
+    func get<T: Decodable>(_ uri: String, using decoder: JSONDecoder = JSONDecoder(), authorization: BasicAuthorization? = nil, headers: HTTPHeaders? = nil) throws -> Future<T> {
+        var request = HTTPRequest(method: .GET, url: uri)
+        if let headers = headers {
+            request.headers = headers
+        }
         return try perform(request, using: decoder, authorization: authorization)
     }
 
-    func post<Body: Content, T: Content>(body: Body, to uri: String, encoder: JSONEncoder = JSONEncoder(), using decoder: JSONDecoder = JSONDecoder(), method: HTTPMethod = .POST, authorization: BasicAuthorization? = nil) throws -> Future<T> {
+    func post<Body: Content, T: Decodable>(body: Body, to uri: String, encoder: JSONEncoder = JSONEncoder(), using decoder: JSONDecoder = JSONDecoder(), method: HTTPMethod = .POST, authorization: BasicAuthorization? = nil) throws -> Future<T> {
         var request = HTTPRequest(method: method, url: uri)
         let data = try encoder.encode(body)
         request.body = HTTPBody(data: data)
@@ -39,31 +42,34 @@ public extension Client {
         return try perform(request, using: decoder, authorization: authorization)
     }
 
-    func perform<T: Content>(_ request: HTTPRequest, using decoder: JSONDecoder = JSONDecoder(), authorization: BasicAuthorization? = nil) throws -> Future<T> {
+    func perform<T: Decodable>(_ request: HTTPRequest, using decoder: JSONDecoder = JSONDecoder(), authorization: BasicAuthorization? = nil) throws -> Future<T> {
         let req = Request(http: request, using: container)
 
-        req.http.headers.basicAuthorization = authorization
+        if let authorization = authorization {
+            req.http.headers.basicAuthorization = authorization
+        }
 
         let futureResult = send(req)
         let featureContent = futureResult.flatMap { response -> EventLoopFuture<T> in
-            guard response.http.status.isSuccessfulRequest else {
-                var responseBody: String?
-                if let data = response.http.body.data {
-                    responseBody = String(data: data, encoding: .utf8)
-                }
-                throw GitHubError.invalidStatus(httpStatus: response.http.status.code, body: responseBody)
-            }
-
-            if T.self is Response.Empty.Type {
-                return self.container.future(Response.Empty() as! T)
-            }
-            let futureDecode = try response.content.decode(json: T.self, using: decoder)
-            futureDecode.whenFailure { error in
-                print("\(request.method.string) \(request.url): \(error)")
-            }
-            return futureDecode
+            return try self.decode(response: response, using: decoder)
         }
 
         return featureContent
+    }
+
+    func decode<T: Decodable>(response: Response, using decoder: JSONDecoder) throws -> Future<T> {
+        guard response.http.status.isSuccessfulRequest else {
+            var responseBody: String?
+            if let data = response.http.body.data {
+                responseBody = String(data: data, encoding: .utf8)
+            }
+            throw GitHubError.invalidStatus(httpStatus: response.http.status.code, body: responseBody)
+        }
+
+        if T.self is Response.Empty.Type {
+            return self.container.future(Response.Empty() as! T)
+        }
+        return try response.content.decode(json: T.self, using: decoder)
+
     }
 }

--- a/Sources/Bob/Core/Extensions/Client+Extensions.swift
+++ b/Sources/Bob/Core/Extensions/Client+Extensions.swift
@@ -25,7 +25,6 @@ extension Response {
 }
 
 public extension Client {
-
     func get<T: Decodable>(_ uri: String, using decoder: JSONDecoder = JSONDecoder(), authorization: BasicAuthorization? = nil, headers: HTTPHeaders? = nil) throws -> Future<T> {
         var request = HTTPRequest(method: .GET, url: uri)
         if let headers = headers {
@@ -70,6 +69,5 @@ public extension Client {
             return self.container.future(Response.Empty() as! T)
         }
         return try response.content.decode(json: T.self, using: decoder)
-
     }
 }

--- a/Sources/Bob/Core/Slack/SlackClient.swift
+++ b/Sources/Bob/Core/Slack/SlackClient.swift
@@ -38,7 +38,6 @@ extension Client {
 
     func loadSlackRealTimeURL(token: String, simpleLatest: Bool = true, noUnreads: Bool = true) throws -> Future<SlackStartResponse.Success> {
         let result = try loadRealtimeApi(token: token).flatMap(to: SlackStartResponse.Success.self) { response in
-
             let slackResponse = try response.content.syncDecode(SlackStartResponse.self)
 
             if !slackResponse.ok {
@@ -47,12 +46,10 @@ extension Client {
             return try response.content.decode(SlackStartResponse.Success.self)
         }
         return result
-
     }
 }
 
 class SlackClient {
-
     // https://api.slack.com/rtm
     enum Event {
         fileprivate enum RawType: String {
@@ -99,8 +96,7 @@ class SlackClient {
         try app.client().loadSlackRealTimeURL(token: token).map { slackResponse in
             logger.info("Connecting to RTM url")
 
-            let _ = try self.app.client().webSocket(slackResponse.url).flatMap { ws -> Future<Void> in
-
+            _ = try self.app.client().webSocket(slackResponse.url).flatMap { ws -> Future<Void> in
                 ws.onText { ws, text in
                     self.onText(ws: ws, text: text, me: slackResponse.me, logger: logger)
                 }
@@ -169,7 +165,6 @@ class SlackClient {
             return nil
         }
         return try event(rawType: rawType, from: data)
-
     }
     private func messageType(fromText text: String) -> (Event.RawType, Data)? {
         guard

--- a/Sources/Bob/Core/Slack/SlackTypes.swift
+++ b/Sources/Bob/Core/Slack/SlackTypes.swift
@@ -43,7 +43,7 @@ struct SlackStartResponse: Decodable {
 }
 
 enum SlackMessageType: String, Encodable {
-    case message = "message"
+    case message
 }
 
 struct SlackMessage: Encodable {

--- a/Sources/Bob/Core/iOS/PListHelpers.swift
+++ b/Sources/Bob/Core/iOS/PListHelpers.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class PListHelpers {
+enum PListHelpers {
     static let versionRegexString: String = "<key>CFBundleShortVersionString<\\/key>\\s*<string>(\\S+)<\\/string>"
     static let versionKey: String = "CFBundleShortVersionString"
     static let buildNumberRegexString: String = "<key>CFBundleVersion<\\/key>\\s*<string>(\\S+)<\\/string>"


### PR DESCRIPTION
- Added Travis REST calls
- Added a `poll` method that polls a `GET /requests/id` until a given condition is met
- After triggering a Travis build, get the request id and poll it until it's out of a "loading" state. After this we can get the build id and construct the web URL to Travis job
- The web URL is posted back to the Slack
- Ran and fixed swiftlint warnings