### PR TITLE
[Bob] Ignore message from bot users

### DIFF
--- a/Sources/Bob/Core/Bob.swift
+++ b/Sources/Bob/Core/Bob.swift
@@ -21,7 +21,7 @@ import Foundation
 import Vapor
 
 public class Bob {
-    static let version: String = "2.2.0"
+    static let version: String = "2.2.1"
     
     /// Struct containing all properties needed for Bob to function
     public struct Configuration {

--- a/Sources/Bob/Core/Slack/SlackClient.swift
+++ b/Sources/Bob/Core/Slack/SlackClient.swift
@@ -64,6 +64,9 @@ class SlackClient {
             let text: String
             let channel: String
             let user: String
+
+            /// All messages with subtype are not user message (e.g. bot_message) and we want to ignore those
+            let subtype: String?
         }
 
         case message(Message)
@@ -137,17 +140,21 @@ class SlackClient {
         do {
             guard let event = try self.event(fromText: text) else { return }
             switch event {
-            case .message(let message):
-                guard message.user != me.id else {
-                    logger.warning("Ignoring message from another instance of myself: '\(message.text)'")
+            case .message(let message) where message.user != me.id:
+                if let subtype = message.subtype {
+                    logger.debug("Ignoring message subtype '\(subtype)'")
                     return
                 }
                 logger.debug("Received message: '\(message.text)'")
                 let sender = SlackMessageSender(socket: ws, channel: message.channel)
                 onMessage?(message.text, sender)
+            case .message(let message) where message.user == me.id:
+                logger.warning("Ignoring message from another instance of myself: '\(message.text)'")
             case .goodbye:
                 logger.info("Received goodbye event. Closing connection")
                 ws.close()
+            default:
+                logger.warning("Unhandled slack event \(event)")
             }
         } catch {
             logger.info("Could not parse Slack event: \(error)")


### PR DESCRIPTION
When Bob posts a URL that he already posted, the Salckbot tells him a message
```json
  "subtype" : "bot_message",
  "text" : "Pssst! I didn’t unfurl <https://exampe.com> because it was already shared in this channel quite recently (within the last hour) and I didn’t want to clutter things up.",
  "type" : "message",
```
and Bob tries to handle it as a command. 

This PR makes Bob ignore all messages with a `subtype` field as those messages are all non user ones. 
See https://api.slack.com/events/message
